### PR TITLE
Remove the native FreeCAD

### DIFF
--- a/CADs/v1 - MVP/CADs/10_NM_StealthMax_Mod_v4.FCStd
+++ b/CADs/v1 - MVP/CADs/10_NM_StealthMax_Mod_v4.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:40d4c9912d1f933d1e9403183453d78fa276bad159d34a7e00011c61cc053a38
-size 17291714

--- a/CADs/v1 - MVP/CADs/11_DC_Barrel_Keystone.FCStd
+++ b/CADs/v1 - MVP/CADs/11_DC_Barrel_Keystone.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a59fc0f7b89f1c04271cef9b5978d2692c89c6d296effd15746bcf5f50a97f9c
-size 1419043

--- a/CADs/v1 - MVP/CADs/12_USB_Daugther_Board_Mount.FCStd
+++ b/CADs/v1 - MVP/CADs/12_USB_Daugther_Board_Mount.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a22bf8e9355735e1172a5b1ee8644a10c17e2f1b69ae7a6b70c3b308898fba74
-size 1312313

--- a/CADs/v1 - MVP/CADs/13_G2E_umbilical_mount.FCStd
+++ b/CADs/v1 - MVP/CADs/13_G2E_umbilical_mount.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:aca4fc3cc4760eea080dd6c5bc68ede73f723941c17691b262169170c77a22b5
-size 3202149

--- a/CADs/v1 - MVP/CADs/14_Lubeballs_Probe.FCStd
+++ b/CADs/v1 - MVP/CADs/14_Lubeballs_Probe.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a333fe923ea15ebac5df9185757532de0f64b07028178bdd029a926941d245d8
-size 227337

--- a/CADs/v1 - MVP/CADs/1_CAN_Cable-v0.1.FCStd
+++ b/CADs/v1 - MVP/CADs/1_CAN_Cable-v0.1.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76f715a7aa1a3b48bd9aa0bcf14486678d6f23d3f5a33443431c4bda11be7f72
-size 9703900

--- a/CADs/v1 - MVP/CADs/2_Endstops_Assembly-v0.4.FCStd
+++ b/CADs/v1 - MVP/CADs/2_Endstops_Assembly-v0.4.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7ab20c34ce24bf4982cc24bffb2ba70c9d57e4d993ee743e8cebb06a98d5c32b
-size 3639959

--- a/CADs/v1 - MVP/CADs/2_Endstops_Assembly-v0.5.FCStd
+++ b/CADs/v1 - MVP/CADs/2_Endstops_Assembly-v0.5.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:398656c2a25b521173db4c3341cec668ef24d925d027886b0aac3a14b8559343
-size 6073451

--- a/CADs/v1 - MVP/CADs/3_XLR_Mount-v0.3.4.FCStd
+++ b/CADs/v1 - MVP/CADs/3_XLR_Mount-v0.3.4.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a53718941fc93cbe26801d46c6ec4f2c0d4037a1cfe2143f582db10bc308c48
-size 428025

--- a/CADs/v1 - MVP/CADs/3_XLR_Mount-v0.3.5.FCStd
+++ b/CADs/v1 - MVP/CADs/3_XLR_Mount-v0.3.5.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a043277587b8a40251fdb7d11b8feafe8e6a681e06abc2be22aa7efbfa087d84
-size 404703

--- a/CADs/v1 - MVP/CADs/4_PTFE_Panel.FCStd
+++ b/CADs/v1 - MVP/CADs/4_PTFE_Panel.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:78c0ae2239ccfe45004d6fd152b878e8d06cdcf5ed32372d70e258bb30e78dae
-size 11732004

--- a/CADs/v1 - MVP/CADs/5_X_Trigger-v0.1.FCStd
+++ b/CADs/v1 - MVP/CADs/5_X_Trigger-v0.1.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a0245e22fe784f1c85fc79d54aaeeb0e56389b5d832ebed29d3234ed935431a
-size 4809309

--- a/CADs/v1 - MVP/CADs/6_Nudge_Mount-v0.1.FCStd
+++ b/CADs/v1 - MVP/CADs/6_Nudge_Mount-v0.1.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2c221906cb51b69c47c4f36d820dd6cfb0ccf730a1f4f45755b80db5483d4990
-size 1208571

--- a/CADs/v1 - MVP/CADs/7_Tap&Change-v3.1.FCStd
+++ b/CADs/v1 - MVP/CADs/7_Tap&Change-v3.1.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e057d2c236b1e7911b32e7505e56bcf08310644b35b187bcda3f3b077b6c5840
-size 5240425

--- a/CADs/v1 - MVP/CADs/7_Tap&Change-v3.2.FCStd
+++ b/CADs/v1 - MVP/CADs/7_Tap&Change-v3.2.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fdb1fbb48a68800f9c69efd5e2d06e28fb659207ebc28991e616451e182b6a9e
-size 801287

--- a/CADs/v1 - MVP/CADs/8_Dock-v3.1.FCStd
+++ b/CADs/v1 - MVP/CADs/8_Dock-v3.1.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:675a8f8b446ad62e938c96f518c5b9410733119012c6419f4ed5a92d4a1a46a8
-size 23850378

--- a/CADs/v1 - MVP/CADs/8_Dock-v3.2.FCStd
+++ b/CADs/v1 - MVP/CADs/8_Dock-v3.2.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0e797e9f3ea1757b1c36847b5c791f1130cb730502fceebfd49ccabde5c3e9ab
-size 484977

--- a/CADs/v1 - MVP/CADs/9_Door_Buffer.FCStd
+++ b/CADs/v1 - MVP/CADs/9_Door_Buffer.FCStd
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b9a3100143c92cb582712d9054cf3b32466a8e8b8b80108a62a7084e21a9e97
-size 11309809

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ BOM, STLs, and instructions for each version of are in their associated sub-fold
 
 The plugin for MissChanger is a fork of [klipper-toolchanger](https://github.com/viesturz/klipper-toolchanger), for [Tapchanger](https://github.com/viesturz/tapchanger), and it is available via GitHub at [VIN-y/klipper-toolchanger](https://github.com/VIN-y/klipper-toolchanger). MissChanger deviate greatly from the design of Tapchanger and Draftshift (Stealthchanger); thus, it's config files are not compatible upstream.
 
-Installation and configuration steps are outlined in the [STL_Config_Instructions](./STL_Config_Instructions) folder. Sample config files and their descriptions are also available in the folder. 
+For the latest **Alpha**, installation and configuration steps are outlined in the [STL_Config_Instructions](./STL_Config_Instructions) folder in their respective sub-folder, with sample config files and descriptions.
+
+For **Beta** and **Release**. All instructions are locked and packaged into the .zip file, in [Releases](https://github.com/VIN-y/MissChanger/releases).
 
 ### Recommended software:
 


### PR DESCRIPTION
To reduce required storage space for the project.

They are sill accessible via the the Archive.