### PR TITLE
Calibration routine optimisation

### DIFF
--- a/Klipper_Config/Alpha/printer.cfg
+++ b/Klipper_Config/Alpha/printer.cfg
@@ -35,10 +35,11 @@
 [gcode_macro _static_variable]
 description: Global static variables that is used through out the configs
 ## Tool-head calibration
-variable_calibration_probe_x: 241.237500     # X aproximate position of the Nudge probe. CHANGE TO MATCH YOUR SET-UP
-variable_calibration_probe_y: 329.825000     # Y aproximate position of the Nudge probe. CHANGE TO MATCH YOUR SET-UP
-variable_calibration_safe_z: 50.00           # Z aproximate safe position of the Nudge probe. KEEP CONSERVATIVE TO AVOID COLLISION
-variable_calibration_min_z: 30.00            # Z aproximate probe position of the Nudge probe.
+variable_calibration_probe_x: 241.237500     # X aproximate position of the calibration probe. CHANGE TO MATCH YOUR SET-UP
+variable_calibration_probe_y: 329.825000     # Y aproximate position of the calibration probe. CHANGE TO MATCH YOUR SET-UP
+variable_calibration_safe_z: 50.00           # Z aproximate safe position of the calibration probe. KEEP CONSERVATIVE TO AVOID COLLISION
+variable_calibration_min_z: 30.00            # Z aproximate probe position of the calibration probe.
+variable_probe_stable_time: 1000             # Time (in ms) to wait for calibration probe to reset. Default: 1000
 variable_calibration_abs_z_seperately: 0     # "0" = False / "1" = True. For, the Nudge probe this should be '1'
 variable_final_lift_z: 3                     # This must be the same as "final_lift_z" in [tools_calibrate] in misschanger_settings.cfg
 ## Cleaning dock

--- a/Klipper_Config/Beta/printer.cfg
+++ b/Klipper_Config/Beta/printer.cfg
@@ -35,10 +35,11 @@
 [gcode_macro _static_variable]
 description: Global static variables that is used through out the configs
 ## Tool-head calibration
-variable_calibration_probe_x: 241.237500     # X aproximate position of the Nudge probe. CHANGE TO MATCH YOUR SET-UP
-variable_calibration_probe_y: 329.825000     # Y aproximate position of the Nudge probe. CHANGE TO MATCH YOUR SET-UP
-variable_calibration_safe_z: 50.00           # Z aproximate safe position of the Nudge probe. KEEP CONSERVATIVE TO AVOID COLLISION
-variable_calibration_min_z: 30.00            # Z aproximate probe position of the Nudge probe.
+variable_calibration_probe_x: 241.237500     # X aproximate position of the calibration probe. CHANGE TO MATCH YOUR SET-UP
+variable_calibration_probe_y: 329.825000     # Y aproximate position of the calibration probe. CHANGE TO MATCH YOUR SET-UP
+variable_calibration_safe_z: 50.00           # Z aproximate safe position of the calibration probe. KEEP CONSERVATIVE TO AVOID COLLISION
+variable_calibration_min_z: 30.00            # Z aproximate probe position of the calibration probe.
+variable_probe_stable_time: 1000             # Time (in ms) to wait for calibration probe to reset. Default: 1000
 variable_calibration_abs_z_seperately: 0     # "0" = False / "1" = True. For, the Nudge probe this should be '1'
 variable_final_lift_z: 3                     # This must be the same as "final_lift_z" in [tools_calibrate] in misschanger_settings.cfg
 ## Cleaning dock


### PR DESCRIPTION
New step: rise and wait 1000ms after z-offset probing, for probe stabilisation. This can be changed via the variable:
```
[gcode_macro _static_variable]
description: Global static variables that is used through out the configs
## Tool-head calibration
variable_probe_stable_time: 1000             # Time (in ms) to wait for calibration probe to reset. Default: 1000

```