### PR TITLE
Update printer.cfg

### DIFF
--- a/Klipper_Config/1_Main/printer.cfg
+++ b/Klipper_Config/1_Main/printer.cfg
@@ -1,5 +1,5 @@
 [include mainsail.cfg]
-## default marcros
+## default macros
 [include misschanger_macros/config_switch.cfg]
 [include misschanger_macros/homing.cfg]
 [include misschanger_macros/nozzle_clean.cfg]
@@ -8,7 +8,7 @@
 [include misschanger_macros/tool_calibrate.cfg]
 [include misschanger_macros/toolchanger.cfg]
 [include misschanger_macros/offsets_adjust_record.cfg]
-# ## optional default marcros
+# ## optional default macros
 # [include misschanger_macros/tool_calibrate_extra.cfg]    # For the Nudge probe
 ## misschanger settings
 [include misschanger_settings.cfg]

--- a/Klipper_Config/README.md
+++ b/Klipper_Config/README.md
@@ -167,7 +167,7 @@ Each variable has been given a short description on what they do. Some variables
    
    These sections need to be placed just before the **SAVE_CONFIG** section, as shown in the sample `printer.cfg`. Everything below the `Section Variable marker` will be swapped in and out upon the `CONFIG_TOGGLE` macro. If a function setting already exists somewhere else in printer.cfg, the old function will need to be transferred to the new location and updated.
    
-   The critical settings that need to be changed are as follow:
+   The critical settings that need to be changed are as follows:
 - `[gcode_macro _home]` needs to adjusted with the appropriate `xh` and `yh` which represents the centre of the new build area (i.e. 150, 85 for a 300x300 bed).
   
   - `variable_dock` is the indicator of which config is being used.


### PR DESCRIPTION
Typo correction: changed 'marcos' to 'macros' in two places